### PR TITLE
Add `after_dependencies`

### DIFF
--- a/custom_components/openhasp/manifest.json
+++ b/custom_components/openhasp/manifest.json
@@ -5,6 +5,7 @@
     "issue_tracker": "https://github.com/HASwitchPlate/openHASP-custom-component/issues",
     "dependencies": ["mqtt", "http"],
     "requirements": ["jsonschema>=3.2.0"],
+    "after_dependencies": ["binary_sensor", "camera", "climate", "cover", "device_tracker", "fan", "group", "light", "media_player", "number", "person", "select", "sensor", "switch", "weather"],
     "version": "0.6.5",
     "config_flow": true,
     "iot_class": "local_push",


### PR DESCRIPTION
`after_dependencies` postpones the loading of the custom component until loading of the integrations specified here finishes first. This is needed in order to avoid template errors generated by openHASP config at startup, due to entities being still unavailable. openHASP should load among the last ones.