### PR TITLE
Replace deprecated async_forward_entry_setup call

### DIFF
--- a/custom_components/openhasp/__init__.py
+++ b/custom_components/openhasp/__init__.py
@@ -264,11 +264,8 @@ async def async_setup_entry(hass, entry) -> bool:
     await component.async_add_entities([plate_entity])
     hass.data[DOMAIN][CONF_PLATE][plate] = plate_entity
 
-    for domain in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, domain)
-        )
-
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    
     listener = entry.add_update_listener(async_update_options)
     entry.async_on_unload(listener)
 


### PR DESCRIPTION
> Calling hass.config_entries.async_forward_entry_setup is deprecated and will be removed in Home Assistant 2025.6. Instead, await hass.config_entries.async_forward_entry_setups as it can load multiple platforms at once and is more efficient since it does not require a separate import executor job for each platform.

https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/