### PR TITLE
Dynamic reloading broken on recently added displays.

### DIFF
--- a/custom_components/openhasp/__init__.py
+++ b/custom_components/openhasp/__init__.py
@@ -554,7 +554,7 @@ class SwitchPlate(RestoreEntity):
         if self._statusupdate:
             num_pages = self._statusupdate[HASP_NUM_PAGES]
 
-            if page <= 0 or int(page) > int(num_pages):
+            if isinstance(page, int) and (page <= 0 or page > num_pages):
                 _LOGGER.error(
                     "Can't change to %s, available pages are 1 to %s", page, num_pages
                 )

--- a/custom_components/openhasp/__init__.py
+++ b/custom_components/openhasp/__init__.py
@@ -554,7 +554,7 @@ class SwitchPlate(RestoreEntity):
         if self._statusupdate:
             num_pages = self._statusupdate[HASP_NUM_PAGES]
 
-            if page <= 0 or page > num_pages:
+            if page <= 0 or int(page) > int(num_pages):
                 _LOGGER.error(
                     "Can't change to %s, available pages are 1 to %s", page, num_pages
                 )


### PR DESCRIPTION
The display stops or refuses to dynamically update (from HA) and throws an error in the logs because (most likely) num_pages contains a string, while page contains an int, resulting in a python type error.