### PR TITLE
Reuse of the same image with different sized displays causes a random resize.

### DIFF
--- a/custom_components/openhasp/__init__.py
+++ b/custom_components/openhasp/__init__.py
@@ -591,7 +591,7 @@ class SwitchPlate(RestoreEntity):
     ):
         """Update object image."""
 
-        image_id = hashlib.md5(image.encode("utf-8")).hexdigest()
+        image_id = hashlib.md5(image.encode("utf-8") + self._entry.data[CONF_NAME].encode('utf-8')).hexdigest()
 
         rgb_image = await self.hass.async_add_executor_job(
             image_to_rgb565, image, (width, height), fitscreen

--- a/custom_components/openhasp/image.py
+++ b/custom_components/openhasp/image.py
@@ -4,7 +4,7 @@ import logging
 import struct
 import tempfile
 
-from PIL import Image
+from PIL import Image, ImageOps
 from aiohttp import hdrs, web
 from homeassistant.components.http.static import CACHE_HEADERS
 from homeassistant.components.http.view import HomeAssistantView
@@ -34,7 +34,9 @@ def image_to_rgb565(in_image, size, fitscreen):
         height = min(h for h in [height, original_height] if h is not None and h > 0)
         im.thumbnail((width, height), Image.LANCZOS)
     else:
-        im = im.resize((width, height), Image.LANCZOS)
+        im = ImageOps.fit(im, (width, height), method = 3,
+                   bleed = 0.0, centering =(0.5, 0.5))
+
     width, height = im.size  # actual size after resize
 
     out_image = tempfile.NamedTemporaryFile(mode="w+b")


### PR DESCRIPTION
When using the same image source more then once, using a md5 hash of the image itself will cause the same image to be overwritten time and time again if you redo the resize for another screen... resulting in an ever changing image size.

This change fixes that and the resize function replacement ImageOps.fit will speed up the image processing compared to the original without sacrificing the quality too much, while preserving the aspect ratios.