### PR TITLE
Use proper entity service schemas & replace async_forward_entry_setup with async_forward_entry_setups

### DIFF
--- a/custom_components/openhasp/__init__.py
+++ b/custom_components/openhasp/__init__.py
@@ -184,26 +184,19 @@ async def async_setup(hass, config):
 
     hass.data[DOMAIN] = {CONF_PLATE: {}}
 
-    component = hass.data[DOMAIN][CONF_COMPONENT] = EntityComponent(
-        _LOGGER, DOMAIN, hass
-    )
+    component = hass.data[DOMAIN][CONF_COMPONENT] = EntityComponent(_LOGGER, DOMAIN, hass)
 
-    component.async_register_entity_service(SERVICE_WAKEUP, {}, "async_wakeup")
-    component.async_register_entity_service(
-        SERVICE_PAGE_NEXT, {}, "async_change_page_next"
-    )
-    component.async_register_entity_service(
-        SERVICE_PAGE_PREV, {}, "async_change_page_prev"
-    )
-    component.async_register_entity_service(
-        SERVICE_PAGE_CHANGE, {vol.Required(ATTR_PAGE): int}, "async_change_page"
-    )
-    component.async_register_entity_service(
-        SERVICE_LOAD_PAGE, {vol.Required(ATTR_PATH): cv.isfile}, "async_load_page"
-    )
-    component.async_register_entity_service(
-        SERVICE_CLEAR_PAGE, {vol.Optional(ATTR_PAGE): int}, "async_clearpage"
-    )
+    WAKEUP_SERVICE_SCHEMA = cv.make_entity_service_schema({})
+    PAGE_NEXT_SERVICE_SCHEMA = cv.make_entity_service_schema({})
+    PAGE_PREV_SERVICE_SCHEMA = cv.make_entity_service_schema({})
+
+    component.async_register_entity_service(SERVICE_WAKEUP, WAKEUP_SCHEMA, "async_wakeup")
+    component.async_register_entity_service(SERVICE_PAGE_NEXT, PAGE_NEXT_SCHEMA, "async_change_page_next")
+    component.async_register_entity_service(SERVICE_PAGE_PREV, PAGE_PREV_SCHEMA, "async_change_page_prev")
+    component.async_register_entity_service(SERVICE_PAGE_CHANGE, {vol.Required(ATTR_PAGE): int}, "async_change_page")
+    component.async_register_entity_service(SERVICE_LOAD_PAGE, {vol.Required(ATTR_PATH): cv.isfile}, "async_load_page")
+    component.async_register_entity_service(SERVICE_CLEAR_PAGE, {vol.Optional(ATTR_PAGE): int}, "async_clearpage")
+
     component.async_register_entity_service(
         SERVICE_COMMAND,
         {


### PR DESCRIPTION
**Pull Request Description:**

This PR addresses two deprecation warnings introduced in upcoming Home Assistant releases:

1. **Proper entity service schemas**

• Previously, services like SERVICE_WAKEUP, SERVICE_PAGE_NEXT, and SERVICE_PAGE_PREV were registered using empty {} schemas, which Home Assistant will stop supporting. Now, these services use cv.make_entity_service_schema({}), ensuring they meet the new requirements for entity service schemas.

1. **Switch to async_forward_entry_setups**

• The integration previously looped over each platform with async_forward_entry_setup, which is deprecated. This has been updated to a single call to async_forward_entry_setups, which aligns with current Home Assistant best practices and avoids deprecation warnings.

  

With these changes, openHASP remains compatible with future Home Assistant releases, preventing warnings and ensuring a smoother user experience.