### PR TITLE
Fix OptionsFlow config_entry setter error in Home Assistant 2024.x+

### DIFF
--- a/custom_components/openhasp/config_flow.py
+++ b/custom_components/openhasp/config_flow.py
@@ -220,15 +220,11 @@ class OpenHASPFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
     @callback
     def async_get_options_flow(config_entry):
         """Set the OptionsFlowHandler."""
-        return OpenHASPOptionsFlowHandler(config_entry)
+        return OpenHASPOptionsFlowHandler()
 
 
 class OpenHASPOptionsFlowHandler(config_entries.OptionsFlow):
     """ConfigOptions flow for openHASP."""
-
-    def __init__(self, config_entry):
-        """Initialize openHASP options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(self, user_input=None):
         """Manage the options."""


### PR DESCRIPTION
## Summary

This PR fixes a critical bug that causes a **500 Internal Server Error** when clicking the gear (⚙️) icon to configure any openHASP plate in Home Assistant 2024.x+ versions.

## Problem

When attempting to access the options flow for any openHASP plate device in Home Assistant, users receive:
```
500 Internal Server Error
```

The underlying error in the logs:
```
AttributeError: property 'config_entry' of 'OpenHASPOptionsFlowHandler' object has no setter
  File "custom_components/openhasp/config_flow.py", line 231, in __init__
    self.config_entry = config_entry
```

## Root Cause

Starting with Home Assistant 2024.x, the `config_entries.OptionsFlow` base class changed `config_entry` from a regular attribute to a **read-only property**. The base class now automatically provides `self.config_entry` to subclasses.

The current code in `OpenHASPOptionsFlowHandler` tries to set `self.config_entry = config_entry` in its `__init__` method, which fails because you cannot assign to a read-only property.

## Solution

Remove the custom `__init__` method from `OpenHASPOptionsFlowHandler` and rely on the base class to provide `self.config_entry` automatically. The `async_get_options_flow` method no longer needs to pass `config_entry` to the constructor.

### Changes Made

**Before:**
```python
@staticmethod
@callback
def async_get_options_flow(config_entry):
    return OpenHASPOptionsFlowHandler(config_entry)

class OpenHASPOptionsFlowHandler(config_entries.OptionsFlow):
    \"\"\"ConfigOptions flow for openHASP.\"\"\"

    def __init__(self, config_entry):
        \"\"\"Initialize openHASP options flow.\"\"\"
        self.config_entry = config_entry

    async def async_step_init(self, user_input=None):
        ...
```

**After:**
```python
@staticmethod
@callback
def async_get_options_flow(config_entry):
    return OpenHASPOptionsFlowHandler()

class OpenHASPOptionsFlowHandler(config_entries.OptionsFlow):
    \"\"\"ConfigOptions flow for openHASP.\"\"\"

    async def async_step_init(self, user_input=None):
        ...
```

## Testing

- ✅ Tested on Home Assistant 2024.x
- ✅ Verified options flow loads correctly for multiple openHASP plates
- ✅ Confirmed all configuration options (idle brightness, pages path) work as expected
- ✅ No regressions observed in plate functionality

## Impact

This fix is **backward compatible** - the base class has provided `config_entry` automatically since HA introduced OptionsFlow. This change simply stops fighting against the framework.

## Additional Notes

This is a minimal, targeted fix. The change:
- Removes 4 lines of code (the `__init__` method)
- Changes 1 line (removes the parameter from constructor call)
- Does not alter any functionality, only removes redundant/broken code

---

**Author:** William Nelson (@wjnelson78)
**Affected versions:** openHASP custom component 0.7.7 with Home Assistant 2024.x+